### PR TITLE
Display Merkle Root Correctly

### DIFF
--- a/genesis.py
+++ b/genesis.py
@@ -196,7 +196,7 @@ def calculate_hashrate(nonce, last_updated):
 
 def print_block_info(options, hash_merkle_root):
   print "algorithm: "    + (options.algorithm)
-  print "merkle hash: "  + hash_merkle_root[::-1].encode('hex_codec')
+  print "merkle hash: "  + hash_merkle_root
   print "pszTimestamp: " + options.timestamp
   print "pubkey: "       + options.pubkey
   print "time: "         + str(options.time)


### PR DESCRIPTION
Remote hex_codec to display Merkle Root correctly.